### PR TITLE
Added promise.all to wait for all files to be processed by uncss

### DIFF
--- a/tasks/uncss.js
+++ b/tasks/uncss.js
@@ -48,11 +48,11 @@ module.exports = function (grunt) {
                 }
             }).catch((error) => {
                 const err = new Error('Uncss failed.');
-    
+
                 if (error.msg) {
                     err.message += `, ${error.msg}.`;
                 }
-    
+
                 err.origError = error;
                 grunt.log.warn(`Uncssing source "${src}" failed.`);
                 grunt.fail.warn(err);


### PR DESCRIPTION
Looks like uncss is moving towards using promises and `grunt-uncss` is exiting early because it is calling done on first file process, In this PR I have updated the `uncss.js` to use the promise returned from the `uncss` module.