### PR TITLE
Fix timing issues with file processing with multiple file sources

### DIFF
--- a/tasks/uncss.js
+++ b/tasks/uncss.js
@@ -2,7 +2,7 @@
  * grunt-uncss
  * https://github.com/uncss/grunt-uncss
  *
- * Copyright (c) 2020 Addy Osmani
+ * Copyright (c) 2019 Addy Osmani
  * Licensed under the MIT license.
  */
 
@@ -18,7 +18,7 @@ module.exports = function (grunt) {
         const options = this.options({
             report: 'min'
         });
-
+        let fileInProcess = 0;
         this.files.forEach(file => {
             const src = file.src.filter(filepath => {
                 if (/^https?:\/\//.test(filepath)) {
@@ -40,7 +40,12 @@ module.exports = function (grunt) {
             }
 
             try {
+                fileInProcess++;
                 uncss(src, options, (error, output, report) => {
+                    fileInProcess--;
+                    if(fileInProcess==0){
+                        done();
+                    }
                     if (error) {
                         throw error;
                     }
@@ -51,8 +56,6 @@ module.exports = function (grunt) {
                     if (typeof options.reportFile !== 'undefined' && options.reportFile.length > 0) {
                         grunt.file.write(options.reportFile, JSON.stringify(report));
                     }
-
-                    done();
                 });
             } catch (error) {
                 const err = new Error('Uncss failed.');


### PR DESCRIPTION
Issue https://github.com/uncss/grunt-uncss/issues/227
I have added a `fileInProcess` counter which is incremented before calling `uncss` and decremented on callback called.
On this flag turns to zero, I am calling the `done()` callback, as opposed to current code which is calling done on first file processed.
